### PR TITLE
Use py3 venv rather than py2 one

### DIFF
--- a/ghbot.rb
+++ b/ghbot.rb
@@ -79,6 +79,16 @@ def remove_rfr_if_present client, repo_name, pr
     client.update_issue(repo_name, pr, :title => pr_title_new)
 end
 
+def remove_wiptest_if_present client, repo_name, pr
+    pull_request = client.pull_request(repo_name, pr)
+    return if pull_request.title.include?('[WIP]')
+    return unless pull_request.title.include?('[WIPTEST]')
+    # Replace WIPTEST with WIP
+    pr_title_new = pull_request.title.gsub(/\[WIPTEST\]/, '[WIP]')
+    client.update_issue(repo_name, pr, :title => pr_title_new)
+end
+
+
 (config["repositories"] || {}).each do |repo_name, repo_data|
     puts "Processing repository #{repo_name} ->"
     repo = client.repository repo_name
@@ -123,6 +133,7 @@ end
                 end
             else
                 remove_rfr_if_present(client, repo_name, pull_request.number)
+                remove_wiptest_if_present(client, repo_name, pull_request.number)
                 puts "  #{pull_request.number} is not mergeable"
                 unless pr_labels.include? needs_rebase_label
                     puts "   add '#{needs_rebase_label}' from #{pull_request.number}"

--- a/loop.sh
+++ b/loop.sh
@@ -16,13 +16,13 @@ ruby -e "require 'git_diff_parser'" >/dev/null 2>&1 || {
     exit 2
 }
 
-if [ ! -e ./ghbot_ve/bin/activate ] ;
+if [ ! -e ./ghbot_ve_py3/bin/activate ] ;
 then
-    virtualenv ghbot_ve
-    . ./ghbot_ve/bin/activate
+    virtualenv ghbot_ve_py3
+    . ./ghbot_ve_py3/bin/activate
     pip install flake8
 else
-. ./ghbot_ve/bin/activate
+. ./ghbot_ve_py3/bin/activate
 fi
 
 while true ;

--- a/loop.sh
+++ b/loop.sh
@@ -18,7 +18,7 @@ ruby -e "require 'git_diff_parser'" >/dev/null 2>&1 || {
 
 if [ ! -e ./ghbot_ve_py3/bin/activate ] ;
 then
-    virtualenv ghbot_ve_py3
+    python3 -m venv ghbot_ve_py3
     . ./ghbot_ve_py3/bin/activate
     pip install flake8
 else


### PR DESCRIPTION
We could just make ghbot_ve be a py3 venv, but I've made it explicitly include py3 in the name. 

Also adding a small function to mark WIPTEST `need-rebase` PRs as WIP